### PR TITLE
Validation attributes added

### DIFF
--- a/docs/Wpf.Themes/Introduction.aml
+++ b/docs/Wpf.Themes/Introduction.aml
@@ -14,6 +14,11 @@
       <content>
         <table>
           <row>
+            <entry><para><externalLink><linkText>Attributes</linkText><linkUri>N_Common_Wpf_Attributes.htm</linkUri><linkTarget>_self</linkTarget></externalLink>
+            <lineBreak/>Package: <ui>Wpf.Resources</ui></para></entry>
+            <entry><para>Contains classes for custom validation attributes.</para></entry>
+          </row>
+          <row>
             <entry><para><externalLink><linkText>Commands</linkText><linkUri>N_Common_Wpf_Commands.htm</linkUri><linkTarget>_self</linkTarget></externalLink>
             <lineBreak/>Package: <ui>Wpf.Resources</ui></para></entry>
             <entry><para>Contains classes that implement the ICommand interface which enables a user to interact with the business logic.</para></entry>

--- a/docs/WpfPackages.shfbproj
+++ b/docs/WpfPackages.shfbproj
@@ -45,12 +45,13 @@
     <WarnOnMissingSourceContext>False</WarnOnMissingSourceContext>
     <NamespaceSummaries>
       <NamespaceSummaryItem name="(global)" isDocumented="False" />
+      <NamespaceSummaryItem name="Common.Wpf.Attributes" isDocumented="True">Contains classes for custom validation attributes.</NamespaceSummaryItem>
       <NamespaceSummaryItem name="Common.Wpf.Commands" isDocumented="True">Contains classes that implement the ICommand interface which enables a user to interact with the business logic.</NamespaceSummaryItem>
       <NamespaceSummaryItem name="Common.Wpf.Controls" isDocumented="True">Contains classes to create elements, known as controls, that enables a user to interact with an application.</NamespaceSummaryItem>
       <NamespaceSummaryItem name="Common.Wpf.Converters" isDocumented="True">Contains classes to convert binding source data to target data.</NamespaceSummaryItem>
       <NamespaceSummaryItem name="Common.Wpf.Rules" isDocumented="True">Contains classes to validate the WPF user interface elements.</NamespaceSummaryItem>
     </NamespaceSummaries>
-    <VisibleItems>ProtectedInternalAsProtected, NonBrowsable</VisibleItems>
+    <VisibleItems>Protected, SealedProtected, ProtectedInternalAsProtected, NonBrowsable</VisibleItems>
     <BuildLogFile>C:\Temp\Documentation\WpfPackages.log</BuildLogFile>
     <ComponentConfigurations>
       <ComponentConfig id="Syntax Component" enabled="True" xmlns="">

--- a/src/Wpf/Controls/Classes/Win32Dialogs.cs
+++ b/src/Wpf/Controls/Classes/Win32Dialogs.cs
@@ -15,7 +15,7 @@ public static class Win32Dialogs
 	// https://learn.microsoft.com/en-us/dotnet/api/microsoft.win32.openfolderdialog
 
 	/// <summary>Displays a standard dialog box that prompts the user to select a folder.</summary>
-	/// <param name="folder">Initial directory..</param>
+	/// <param name="folder">Initial directory.</param>
 	/// <returns>The selected folder path. If nothing is selected an empty string is returned.</returns>
 	public static string ShowSelectFolder( string? folder )
 	{

--- a/src/Wpf/Controls/ComboBox.cs
+++ b/src/Wpf/Controls/ComboBox.cs
@@ -19,7 +19,7 @@ public class ComboBox : System.Windows.Controls.ComboBox
 		typeMetadata: new PropertyMetadata( defaultValue: false ) );
 
 	/// <summary>Gets or sets whether error messages are shown to the user below the control.
-	/// The default is false.</summary>
+	/// The default is <see langword="false"/>.</summary>
 	public bool IsErrorShown
 	{
 		get { return (bool)GetValue( IsErrorShownProperty ); }
@@ -38,10 +38,6 @@ public class ComboBox : System.Windows.Controls.ComboBox
 		DefaultStyleKeyProperty.OverrideMetadata( typeof( ComboBox ),
 			new FrameworkPropertyMetadata( typeof( ComboBox ) ) );
 	}
-
-	/// <summary>Initializes a new instance of the ComboBox class.</summary>
-	public ComboBox()
-	{ }
 
 	#endregion
 }

--- a/src/Wpf/Controls/DatePicker.cs
+++ b/src/Wpf/Controls/DatePicker.cs
@@ -19,7 +19,7 @@ public class DatePicker : System.Windows.Controls.DatePicker
 		typeMetadata: new PropertyMetadata( defaultValue: false ) );
 
 	/// <summary>Gets or sets whether error messages are shown to the user below the control.
-	/// The default is false.</summary>
+	/// The default is <see langword="false"/>.</summary>
 	public bool IsErrorShown
 	{
 		get { return (bool)GetValue( IsErrorShownProperty ); }
@@ -38,10 +38,6 @@ public class DatePicker : System.Windows.Controls.DatePicker
 		DefaultStyleKeyProperty.OverrideMetadata( typeof( DatePicker ),
 			new FrameworkPropertyMetadata( typeof( DatePicker ) ) );
 	}
-
-	/// <summary>Initializes a new instance of the DatePicker class.</summary>
-	public DatePicker()
-	{ }
 
 	#endregion
 }

--- a/src/Wpf/Controls/FilePathTextBox.cs
+++ b/src/Wpf/Controls/FilePathTextBox.cs
@@ -37,7 +37,7 @@ public class FilePathTextBox : TextBox
 			new PropertyMetadata( DialogTypes.File ) );
 
 	/// <summary>Gets or sets the dialog type that will be shown to the user.<br/>
-	/// The default is File.</summary>
+	/// The default is <c>File</c>.</summary>
 	/// <remarks>File names must have an extension.</remarks>
 	public DialogTypes DialogType
 	{
@@ -63,7 +63,7 @@ public class FilePathTextBox : TextBox
 		typeMetadata: new PropertyMetadata( defaultValue: false ) );
 
 	/// <summary>Gets or sets whether error messages are shown to the user below the control.
-	/// The default is false.</summary>
+	/// The default is <see langword="false"/>.</summary>
 	public bool IsErrorShown
 	{
 		get { return (bool)GetValue( IsErrorShownProperty ); }

--- a/src/Wpf/Controls/HamburgerMenu.cs
+++ b/src/Wpf/Controls/HamburgerMenu.cs
@@ -35,7 +35,7 @@ public class HamburgerMenu : Control
 			typeMetadata: new PropertyMetadata( defaultValue: false,
 				propertyChangedCallback: OnIsOpenPropertyChanged ) );
 
-	/// <summary>Gets or sets the menu open indicator. The default is false.</summary>
+	/// <summary>Gets or sets the menu open indicator. The default is <see langword="false"/>.</summary>
 	public bool IsOpen
 	{
 		get { return (bool)GetValue( IsOpenProperty ); }
@@ -47,7 +47,7 @@ public class HamburgerMenu : Control
 		DependencyProperty.Register( nameof( OpenCloseDuration ), typeof( Duration ),
 			typeof( HamburgerMenu ), new PropertyMetadata( defaultValue: Duration.Automatic ) );
 
-	/// <summary>Gets or sets the menu open duration. The default is Automatic.</summary>
+	/// <summary>Gets or sets the menu open duration. The default is <c>Automatic</c>.</summary>
 	public Duration OpenCloseDuration
 	{
 		get { return (Duration)GetValue( OpenCloseDurationProperty ); }
@@ -59,7 +59,7 @@ public class HamburgerMenu : Control
 		DependencyProperty.Register( nameof( FallBackOpenWidth ), typeof( double ),
 			typeof( HamburgerMenu ), new PropertyMetadata( 100.0 ) );
 
-	/// <summary>Gets or sets the fall-back menu open width. The default is 100.</summary>
+	/// <summary>Gets or sets the fall-back menu open width. The default is <c>100</c>.</summary>
 	public double FallBackOpenWidth
 	{
 		get { return (double)GetValue( FallBackOpenWidthProperty ); }

--- a/src/Wpf/Controls/NumericSpinner.cs
+++ b/src/Wpf/Controls/NumericSpinner.cs
@@ -35,7 +35,7 @@ public class NumericSpinner : TextBox
 		typeMetadata: new PropertyMetadata( defaultValue: new decimal( 1 ) ) );
 
 	/// <summary>Gets or sets the increase/decrease value whenever a button is used.
-	/// The default is one.</summary>
+	/// The default is <c>one</c>.</summary>
 	public decimal Step
 	{
 		get { return (decimal)GetValue( StepProperty ); }
@@ -50,7 +50,7 @@ public class NumericSpinner : TextBox
 		name: nameof( Decimals ), propertyType: typeof( int ), ownerType: typeof( NumericSpinner ),
 		typeMetadata: new PropertyMetadata( defaultValue: 0 ) );
 
-	/// <summary>Gets or sets the number of decimals to display. The default is zero.</summary>
+	/// <summary>Gets or sets the number of decimals to display. The default is <c>zero</c>.</summary>
 	public int Decimals
 	{
 		get { return (int)GetValue( DecimalsProperty ); }
@@ -65,7 +65,7 @@ public class NumericSpinner : TextBox
 		name: nameof( MinValue ), propertyType: typeof( decimal ), ownerType: typeof( NumericSpinner ),
 		typeMetadata: new PropertyMetadata( defaultValue: decimal.MinValue ) );
 
-	/// <summary>Gets or sets the minimum value allowed. The default is decimal minimum.</summary>
+	/// <summary>Gets or sets the minimum value allowed. The default is <c>decimal minimum</c>.</summary>
 	public decimal MinValue
 	{
 		get { return (decimal)GetValue( MinValueProperty ); }
@@ -81,7 +81,7 @@ public class NumericSpinner : TextBox
 		name: nameof( MaxValue ), propertyType: typeof( decimal ), ownerType: typeof( NumericSpinner ),
 		typeMetadata: new PropertyMetadata( defaultValue: decimal.MaxValue ) );
 
-	/// <summary>Gets or sets the maximum value allowed. The default is decimal maximum.</summary>
+	/// <summary>Gets or sets the maximum value allowed. The default is <c>decimal maximum</c>.</summary>
 	public decimal MaxValue
 	{
 		get { return (decimal)GetValue( MaxValueProperty ); }
@@ -98,7 +98,7 @@ public class NumericSpinner : TextBox
 		typeMetadata: new PropertyMetadata( defaultValue: false ) );
 
 	/// <summary>Gets or sets whether error messages are shown to the user below the control.
-	/// The default is false.</summary>
+	/// The default is <see langword="false"/>.</summary>
 	public bool IsErrorShown
 	{
 		get { return (bool)GetValue( IsErrorShownProperty ); }

--- a/src/Wpf/Controls/PasswordBoxExtend.cs
+++ b/src/Wpf/Controls/PasswordBoxExtend.cs
@@ -112,7 +112,7 @@ public static class PasswordBoxExtend
 
 	/// <summary>Gets the Bind Password property.</summary>
 	/// <param name="dp">Dependency object.</param>
-	/// <returns>True if the password is bound, otherwise false is returned.</returns>
+	/// <returns><see langword="true"/> if the password is bound, otherwise <see langword="false"/> is returned.</returns>
 	public static bool GetBindPassword( DependencyObject dp ) => (bool)dp.GetValue( BindPassword );
 
 	/// <summary>Sets the Bound Password property.</summary>

--- a/src/Wpf/Controls/SortableListView.cs
+++ b/src/Wpf/Controls/SortableListView.cs
@@ -49,7 +49,7 @@ public class SortableListView : ListView
 		typeMetadata: new PropertyMetadata( defaultValue: cDftColIndex ) );
 
 	/// <summary>Gets or sets the default one-based column index.<br/>
-	/// The default value is 1.</summary>
+	/// The default value is <c>1</c>.</summary>
 	public int DefaultColumn
 	{
 		get => (int)GetValue( DefaultColumnProperty );
@@ -88,15 +88,13 @@ public class SortableListView : ListView
 			new FrameworkPropertyMetadata( typeof( SortableListView ) ) );
 	}
 
-	/// <summary>Initializes a new instance of the SortableListView class.</summary>
-	public SortableListView() { }
-
 	#endregion
 
 	#region Public Methods
 
 	/// <summary>Sorts the list view on a one-based column index.</summary>
-	/// <param name="columnIndex">Column index to use as the default sort column.</param>
+	/// <param name="columnIndex">Column index to use as the default sort column.
+	/// The default value is <c>1</c>.</param>
 	/// <remarks>This method should be called when the list view is first initialized.</remarks>
 	public void Sort( int columnIndex = cDftColIndex )
 	{

--- a/src/Wpf/Resources/Attributes/NoFutureDateAttribute.cs
+++ b/src/Wpf/Resources/Attributes/NoFutureDateAttribute.cs
@@ -1,0 +1,38 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Common.Wpf.Attributes;
+
+/// <summary>Validates that a date is not in the future.</summary>
+/// <remarks>This works for both <see cref="DateTime">DateTime</see> and <see cref="DateOnly">DateOnly</see> values.</remarks>
+[AttributeUsage( AttributeTargets.Property, AllowMultiple = false, Inherited = true )]
+public sealed class NoFutureDateAttribute : ValidationAttribute
+{
+	/// <inheritdoc/>
+	public override string FormatErrorMessage( string name )
+	{
+		return $"{name} cannot be in the future.";
+	}
+
+	/// <inheritdoc/>
+	protected override ValidationResult? IsValid( object? value, ValidationContext validationContext )
+	{
+		if( validationContext.ObjectInstance is not null && validationContext.MemberName is not null &&
+			value is not null )
+		{
+			DateOnly? dateOnly = null;
+			if( value is DateTime dt ) { dateOnly = DateOnly.FromDateTime( dt ); }
+			else if( value is DateOnly d ) { dateOnly = d; }
+
+			if( dateOnly is not null )
+			{
+				if( dateOnly > DateOnly.FromDateTime( DateTime.Now ) )
+				{
+					return new( FormatErrorMessage( validationContext.DisplayName ),
+						new string[] { validationContext.MemberName } );
+				}
+			}
+		}
+
+		return ValidationResult.Success;
+	}
+}

--- a/src/Wpf/Resources/Attributes/RegExAttribute.cs
+++ b/src/Wpf/Resources/Attributes/RegExAttribute.cs
@@ -1,0 +1,8 @@
+﻿namespace Common.Wpf.Attributes;
+
+/// <summary>Regular Expression validation attributes.</summary>
+public class RegExAttribute
+{
+	/// <summary>Simple email format.</summary>
+	public const string cEmail = @".+@.+\..+";
+}

--- a/src/Wpf/Resources/Common.Wpf.Resources.csproj
+++ b/src/Wpf/Resources/Common.Wpf.Resources.csproj
@@ -12,10 +12,8 @@
 
   <!-- Package Information -->
   <PropertyGroup>
-    <Version>2.0.3</Version>
-    <PackageReleaseNotes>* Fixed DateOnly Rule so it doesn't wipe out invalid values.
-* Added ability for DelegateCommand to monitor for changes to a specific object and properties.
-* Added common styles for the PasswordBox control.</PackageReleaseNotes>
+    <Version>2.0.4</Version>
+    <PackageReleaseNotes>* Added attribute validations for NoFutureDate and a cEmail constant for regular expressions.</PackageReleaseNotes>
     <PackageId>kdheath.Wpf.Resources</PackageId>
     <PackageDescription>Provides UI resources for .NET Windows Presentation Foundation applications.</PackageDescription>
     <PackageProjectUrl>https://kevindheath.github.io/shfb</PackageProjectUrl>

--- a/src/Wpf/Resources/README.md
+++ b/src/Wpf/Resources/README.md
@@ -2,6 +2,8 @@
 Provides UI resources for .NET Windows Presentation Foundation applications.
 
 ## Change Log
+- v2.0.4
+  - Added attribute validations for `NoFutureDate` and a `cEmail` constant for regular expressions.
 - v2.0.3
   - Fixed `DateOnly` rule so it doesn't wipe out invalid values. 
   - Added ability for `DelegateCommand` to monitor changes to a specific object and properties.

--- a/src/Wpf/Resources/Rules/DateOnlyRule.cs
+++ b/src/Wpf/Resources/Rules/DateOnlyRule.cs
@@ -11,7 +11,7 @@ public class DateOnlyRule : RuleBase
 {
 	#region Properties
 
-	/// <summary>Indicates if a value is required. The default is false.</summary>
+	/// <summary>Indicates if a value is required. The default is <see langword="false"/>.</summary>
 	public bool Rqd { get; set; }
 
 	#endregion

--- a/src/Wpf/Resources/Rules/IntegerRule.cs
+++ b/src/Wpf/Resources/Rules/IntegerRule.cs
@@ -11,13 +11,13 @@ public class IntegerRule : RuleBase
 {
 	#region Properties and Constructor
 
-	/// <summary>Minimum value. The default is -2,147,483,648.</summary>
+	/// <summary>Minimum value. The default is <c>-2,147,483,648</c>.</summary>
 	public int Min { get; set; }
 
-	/// <summary>Maximum value. The default is 2,147,483,647.</summary>
+	/// <summary>Maximum value. The default is <c>2,147,483,647</c>.</summary>
 	public int Max { get; set; }
 
-	/// <summary>Indicates if a value is required. The default is false.</summary>
+	/// <summary>Indicates if a value is required. The default is <see langword="false"/>.</summary>
 	public bool Rqd { get; set; }
 
 	/// <summary>Initializes a new instance of the IntegerRule class.</summary>

--- a/src/Wpf/Resources/Rules/RequiredRule.cs
+++ b/src/Wpf/Resources/Rules/RequiredRule.cs
@@ -9,16 +9,10 @@ namespace Common.Wpf.Rules;
 /// </summary>
 public class RequiredRule : RuleBase
 {
-	#region Properties and Constructor
+	#region Properties
 
-	/// <summary>Minimum number of characters. The default is 1.</summary>
-	public int Min { get; set; }
-
-	/// <summary>Initializes a new instance of the RequiredRule class.</summary>
-	public RequiredRule()
-	{
-		Min = 1;
-	}
+	/// <summary>Minimum number of characters. The default is <c>1</c>.</summary>
+	public int Min { get; set; } = 1;
 
 	#endregion
 

--- a/test/Samples/Mvvm/ViewModels/UserViewModel.cs
+++ b/test/Samples/Mvvm/ViewModels/UserViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Windows.Input;
+using Common.Wpf.Attributes;
 using Common.Wpf.Commands;
 using Sample.Mvvm.Models;
 using Sample.Mvvm.Validations;
@@ -25,7 +26,7 @@ public class UserViewModel : ViewModelBase
 	}
 
 	[Required( ErrorMessage = "{0} cannot be empty." )]
-	[RegularExpression( cEmailRegex, ErrorMessage = "Format not valid." )]
+	[RegularExpression( RegExAttribute.cEmail, ErrorMessage = "Format not valid." )]
 	[StringLength( 50, ErrorMessage = "{0} cannot be longer than {1}." )]
 	[UserEmail]
 	public string Email
@@ -33,7 +34,7 @@ public class UserViewModel : ViewModelBase
 		get => _mod.Email;
 		set
 		{
-			value = value.Trim(); // Whitespace not allowed
+			value = value.Trim(); // No spaces allowed
 			ValidateProperty( value );
 			_mod.Email = value;
 			OnPropertyChanged();
@@ -41,6 +42,8 @@ public class UserViewModel : ViewModelBase
 	}
 
 	[Required( ErrorMessage = "{0} cannot be empty." )]
+	[NoFutureDate]
+	[Display( Name = "Birthday" )]
 	public DateOnly? BirthDate
 	{
 		get => _mod.BirthDate;

--- a/test/Samples/Mvvm/ViewModels/ViewModelBase.cs
+++ b/test/Samples/Mvvm/ViewModels/ViewModelBase.cs
@@ -4,7 +4,5 @@ namespace Sample.Mvvm.ViewModels;
 
 public class ViewModelBase : ModelDataError, IDisposable
 {
-	protected  const string cEmailRegex = @".+@.+\..+";
-
 	public virtual void Dispose() { GC.SuppressFinalize( this ); }
 }

--- a/test/Samples/Wpf/Views/HomeView.xaml
+++ b/test/Samples/Wpf/Views/HomeView.xaml
@@ -20,11 +20,13 @@
       <self:ComponentsList Component="DecimalToString" View="Unit Tests" Type="Converter"/>
       <self:ComponentsList Component="DelegateCommand" View="Command Test" Type="Command"/>
       <self:ComponentsList Component="DoubleToString" View="Unit Tests" Type="Converter"/>
+      <self:ComponentsList Component="EmailRegEx" View="User Edit" Type="Attribute"/>
       <self:ComponentsList Component="FilePathTextBox" View="Unit Tests" Type="Control"/>
       <self:ComponentsList Component="HamburgerMenu" View="This App" Type="Control"/>
       <self:ComponentsList Component="IntegerRule" View="Unit Tests" Type="Rule"/>
       <self:ComponentsList Component="IntegerToString" View="Unit Tests" Type="Converter"/>
       <self:ComponentsList Component="ModalDialog" View="Login" Type="Control"/>
+      <self:ComponentsList Component="NoFutureDate" View="User Edit" Type="Attribute"/>
       <self:ComponentsList Component="NumericSpinner" View="Unit Tests" Type="Control"/>
       <self:ComponentsList Component="PasswordExtend" View="Login" Type="Control"/>
       <self:ComponentsList Component="RelayCommand" View="Unit Tests" Type="Command"/>


### PR DESCRIPTION
Added attribute validations for `NoFutureDate` and a `cEmail` constant for regular expressions to the `Wpf.Resources` package and updated the version number to 2.0.4

No other common validation attributes were found in the repositories, they are all very specific to the individual projects.

While testing this modification in the `HomeBase` repository it was necessary to reference the new package in the `MVVM.Core` project. This resulted in having to change the target framework for that project from .NET 8 to .NET 8-windows and to add the `UseWpf=true` property. This means that the use of these attributes in non-UI components results in making them Windows specific.

These changes closes #28 with that caveat.
