### PR TITLE
Add history reporting for all unit test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
     branches:
       - main
-      - report-history 
     inputs:
       run-name:
         description: A name for the run
@@ -46,16 +45,16 @@ jobs:
         shell: pwsh
         run: .\test\Unit\RunTests.ps1 ${{ env.ARTIFACT_PATH }}
 
-      # - name: Core coverage report
-      #   uses: danielpalme/ReportGenerator-GitHub-Action@5.2.2
-      #   with:
-      #     reports: ${{ env.ARTIFACT_PATH }}\TestResults\core\*\coverage.cobertura.xml
-      #     targetdir: ${{ env.ARTIFACT_PATH }}\TestResults\core\reports
-      #     reporttypes: 'Html;Badges;MarkdownSummaryGithub'
-      #     historydir: ${{ env.ARTIFACT_PATH }}\TestResults\core\history
-      #     verbosity: 'Info'
-      #     customSettings: 'settings:createSubdirectoryForAllReportTypes=true'
-      #     toolpath: 'reportgeneratortool'
+      - name: Core coverage report
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.2.2
+        with:
+          reports: ${{ env.ARTIFACT_PATH }}\TestResults\core\*\coverage.cobertura.xml
+          targetdir: ${{ env.ARTIFACT_PATH }}\TestResults\core\reports
+          reporttypes: 'Html;Badges;MarkdownSummaryGithub'
+          historydir: ${{ env.ARTIFACT_PATH }}\TestResults\core\history
+          verbosity: 'Warning'
+          customSettings: 'settings:createSubdirectoryForAllReportTypes=true'
+          toolpath: 'reportgeneratortool'
 
       - name: Helper coverage report
         uses: danielpalme/ReportGenerator-GitHub-Action@5.2.2
@@ -64,7 +63,7 @@ jobs:
           targetdir: ${{ env.ARTIFACT_PATH }}\TestResults\helper\reports
           reporttypes: 'Html;Badges;MarkdownSummaryGithub'
           historydir: ${{ env.ARTIFACT_PATH }}\TestResults\helper\history
-          verbosity: 'Info'
+          verbosity: 'Warning'
           customSettings: 'settings:createSubdirectoryForAllReportTypes=true'
           toolpath: 'reportgeneratortool'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
     branches:
       - main
+      - report-history 
     inputs:
       run-name:
         description: A name for the run
@@ -45,28 +46,32 @@ jobs:
         shell: pwsh
         run: .\test\Unit\RunTests.ps1 ${{ env.ARTIFACT_PATH }}
 
-      - name: Core coverage report
-        uses: danielpalme/ReportGenerator-GitHub-Action@5.2.2
-        with:
-          reports: ${{ env.ARTIFACT_PATH }}\TestResults\core\*\coverage.cobertura.xml
-          targetdir: ${{ env.ARTIFACT_PATH }}\TestResults\core\reports\html
-          reporttypes: 'Html'
-          verbosity: 'Info'
-          toolpath: 'reportgeneratortool'
+      # - name: Core coverage report
+      #   uses: danielpalme/ReportGenerator-GitHub-Action@5.2.2
+      #   with:
+      #     reports: ${{ env.ARTIFACT_PATH }}\TestResults\core\*\coverage.cobertura.xml
+      #     targetdir: ${{ env.ARTIFACT_PATH }}\TestResults\core\reports
+      #     reporttypes: 'Html;Badges;MarkdownSummaryGithub'
+      #     historydir: ${{ env.ARTIFACT_PATH }}\TestResults\core\history
+      #     verbosity: 'Info'
+      #     customSettings: 'settings:createSubdirectoryForAllReportTypes=true'
+      #     toolpath: 'reportgeneratortool'
 
       - name: Helper coverage report
         uses: danielpalme/ReportGenerator-GitHub-Action@5.2.2
         with:
           reports: ${{ env.ARTIFACT_PATH }}\TestResults\helper\*\coverage.cobertura.xml
-          targetdir: ${{ env.ARTIFACT_PATH }}\TestResults\helper\reports\html
-          reporttypes: 'Html'
+          targetdir: ${{ env.ARTIFACT_PATH }}\TestResults\helper\reports
+          reporttypes: 'Html;Badges;MarkdownSummaryGithub'
+          historydir: ${{ env.ARTIFACT_PATH }}\TestResults\helper\history
           verbosity: 'Info'
+          customSettings: 'settings:createSubdirectoryForAllReportTypes=true'
           toolpath: 'reportgeneratortool'
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Test-Artifacts
+          name: UnitTest-Artifacts
           path: ${{ env.ARTIFACT_PATH }}
           retention-days: 5
 

--- a/test/Unit/README.md
+++ b/test/Unit/README.md
@@ -24,6 +24,7 @@ Dependencies:\
 
 To install or update the ReportGenerator package as a global .NET tool use  the following `powershell` commands:
 ```shell
+dotnet tool list --global
 dotnet tool install --global dotnet-reportgenerator-globaltool
 
 dotnet tool update --global dotnet-reportgenerator-globaltool

--- a/test/Unit/RunTests.ps1
+++ b/test/Unit/RunTests.ps1
@@ -7,7 +7,7 @@ function DotNet_Test {
   $history = "$results\history"
 
   # Build projects and run unit tests
-  Push-Location "$output\$testProject"
+  Push-Location "$PSScriptRoot\$testProject"
   if( "$PSScriptRoot" -eq "$output" ) { dotnet clean | Out-Null }
   dotnet build --no-restore
   if( $LASTEXITCODE -gt 0 ) { Pop-Location; exit 1 }

--- a/test/Unit/RunTests.ps1
+++ b/test/Unit/RunTests.ps1
@@ -34,5 +34,5 @@ function DotNet_Test {
 }
 
 # Perform tasks  
-#DotNet_Test 'Core.Tests'
+DotNet_Test 'Core.Tests'
 DotNet_Test 'Helper.Tests'

--- a/test/Unit/RunTests.ps1
+++ b/test/Unit/RunTests.ps1
@@ -16,7 +16,7 @@ function DotNet_Test {
   Pop-Location
 
   # Copy the oldest 3 history files
-  $wrk = "$output\$testProject\Testdata\history"
+  $wrk = "$PSScriptRoot\$testProject\Testdata\history"
   if( !(Test-Path "$history") ) { New-Item -ItemType Directory -Path "$history" | Out-Null }
   foreach( $file in ( Get-ChildItem "$wrk" -Filter *.xml | Sort-Object -Property FullName | Select-Object -First 3 ) )
   { Copy-Item -Path "$file" -Destination "$history" }

--- a/test/Unit/RunTests.ps1
+++ b/test/Unit/RunTests.ps1
@@ -4,17 +4,22 @@ if( "" -eq $outputRoot ) { $output = "$PSScriptRoot" } else { $output = "$output
 function DotNet_Test {
   param($testProject)
   $results = "$output\TestResults\" + $testProject.split('.')[0].ToLower()
-  $history = "$PSScriptRoot\$testProject\Testdata\history"
+  $history = "$results\history"
 
-  # Remove existing results
-  if( Test-Path "$results" ) { Remove-Item -Path "$results\*" -Recurse | Out-Null }
-
-  # Build project and run unit tests
-  Set-Location "$PSScriptRoot\$testProject"
+  # Build projects and run unit tests
+  Push-Location "$output\$testProject"
   if( "$PSScriptRoot" -eq "$output" ) { dotnet clean | Out-Null }
   dotnet build --no-restore
+  if( $LASTEXITCODE -gt 0 ) { Pop-Location; exit 1 }
+  if( Test-Path "$results" ) { Remove-Item -Path "$results\*" -Recurse | Out-Null }
   dotnet test --collect:"XPlat Code Coverage" --no-build --results-directory "$results"
-  Set-Location $PSScriptRoot
+  Pop-Location
+
+  # Copy the oldest 3 history files
+  $wrk = "$output\$testProject\Testdata\history"
+  if( !(Test-Path "$history") ) { New-Item -ItemType Directory -Path "$history" | Out-Null }
+  foreach( $file in ( Get-ChildItem "$wrk" -Filter *.xml | Sort-Object -Property FullName | Select-Object -First 3 ) )
+  { Copy-Item -Path "$file" -Destination "$history" }
 
   # If running locally generate reports
   if( "$PSScriptRoot" -eq "$output" ) {
@@ -24,27 +29,10 @@ function DotNet_Test {
     $title = "-title:$testProject"
 
     Write-Host "Generating coverage reports for $testProject" -ForegroundColor Yellow
-    reportgenerator -reports:"$reports" -targetdir:"$results\reports" $title -verbosity:Warning $rpTypes $setting
-
-     # Tidy up output
-    $wrk = "$results\reports\Html"
-    if( Test-Path "$wrk" ) { Rename-Item -path "$wrk" -NewName "html" }
-
-    $wrk = "$results\reports\Badges" # Move required badges
-    if( Test-Path "$wrk" ) {
-      Remove-Item "$wrk\badge_shieldsio_*.svg" | Out-Null
-      Move-Item -Path "$wrk\*.svg" -Destination "$results\reports"
-      Remove-Item "$wrk"
-    }
-
-    $wrk = "$results\reports\MarkdownSummaryGithub" # Move required markdown
-    if( Test-Path "$wrk" ) {
-      Move-Item -Path "$wrk\*.md" -Destination "$results\reports"
-      Remove-Item "$wrk"
-    }
+    reportgenerator -reports:"$reports" -targetdir:"$results\reports" -historydir:$history $title -verbosity:Warning $rpTypes $setting
   }
 }
 
 # Perform tasks  
-DotNet_Test 'Core.Tests'
+#DotNet_Test 'Core.Tests'
 DotNet_Test 'Helper.Tests'


### PR DESCRIPTION
The history files are now included in the `UnitTest-Artifacts.zip` for the Run Tests action.

These can be downloaded and used to update the reports on GitHub pages.\
If necessary the associated `*CoverageHistory.xml` files can be committed in the test project `Testdata\history` folder.\
*Note:* The history report includes the oldest 3 coverage history files plus the one generated in the run.