### PR TITLE
Fix Integration Testing of Rules

### DIFF
--- a/tests/Integration/Mvvm/ViewModels/UnitTestViewModel.cs
+++ b/tests/Integration/Mvvm/ViewModels/UnitTestViewModel.cs
@@ -52,7 +52,6 @@ public class UnitTestViewModel : ViewModelBase
 		get => _settings.ComboEditRule;
 		set
 		{
-			if( value.Equals( _settings.ComboEditRule ) ) { return; }
 			_settings.ComboEditRule = value;
 			OnPropertyChanged();
 		}
@@ -87,7 +86,6 @@ public class UnitTestViewModel : ViewModelBase
 		get => _settings.DateOnlyVal;
 		set
 		{
-			if( value is not null && value.Equals( _settings.DateOnlyVal ) ) { return; }
 			_settings.DateOnlyVal = value;
 			OnPropertyChanged();
 		}
@@ -132,7 +130,6 @@ public class UnitTestViewModel : ViewModelBase
 		get => _settings.IntegerRule;
 		set
 		{
-			if( value is not null && value.Equals( _settings.IntegerRule ) ) { return; }
 			_settings.IntegerRule = value;
 			OnPropertyChanged();
 		}
@@ -154,7 +151,6 @@ public class UnitTestViewModel : ViewModelBase
 		get => _settings.StringRule;
 		set
 		{
-			if( value is not null && value.Equals( _settings.StringRule ) ) { return; }
 			_settings.StringRule = value;
 			OnPropertyChanged();
 		}
@@ -170,6 +166,8 @@ public class UnitTestViewModel : ViewModelBase
 			OnPropertyChanged();
 		}
 	}
+
+	public int UIErrors { get; set; }
 
 	#endregion
 
@@ -205,7 +203,7 @@ public class UnitTestViewModel : ViewModelBase
 		}
 	}
 
-	private bool IsDirty() => _settings.HasChanges( _orgValue );
+	private bool IsDirty() => _settings.HasChanges( _orgValue ) || UIErrors > 0;
 
 	public void DoCancelEdit()
 	{
@@ -225,7 +223,7 @@ public class UnitTestViewModel : ViewModelBase
 		StringVal = _orgValue.StringVal;
 	}
 
-	private bool CanCommitEdit() => !HasErrors && IsDirty();
+	private bool CanCommitEdit() => !HasErrors && UIErrors == 0 && IsDirty();
 
 	private void DoCommitEdit()
 	{

--- a/tests/Integration/Wpf/Views/UnitTestView.xaml
+++ b/tests/Integration/Wpf/Views/UnitTestView.xaml
@@ -171,12 +171,13 @@
           <!-- ComboEditRule -->
           <TextBlock Grid.Row="0" Text="ComboEdit:"
                      Style="{StaticResource appTextBlockStyle}"/>
-          <cc:ComboBox Grid.Row="0" Grid.Column="1" MinWidth="210" Style="{StaticResource appLayoutStyle}"
+          <cc:ComboBox Grid.Row="0" Grid.Column="1" MinWidth="210" Validation.Error="ItemError"
+                       Style="{StaticResource appLayoutStyle}"
                        ItemsSource="{Binding TestTypes}" IsErrorShown="True" IsEditable="True">
             <ComboBox.SelectedItem>
-              <Binding Path="ComboEditRule" UpdateSourceTrigger="LostFocus">
+              <Binding Path="ComboEditRule" UpdateSourceTrigger="PropertyChanged" NotifyOnValidationError="True">
                 <Binding.ValidationRules>
-                  <cr:ComboEditRule Property="ComboEditRule" ValidationStep="RawProposedValue" ValidatesOnTargetUpdated="True"/>
+                  <cr:ComboEditRule Property="ComboEditRule"/>
                 </Binding.ValidationRules>
               </Binding>
             </ComboBox.SelectedItem>
@@ -185,12 +186,12 @@
           <!-- DateOnlyRule -->
           <TextBlock Grid.Row="1" Text="DateOnly:"
                Style="{StaticResource appTextBlockStyle}"/>
-          <TextBox Grid.Row="1" Grid.Column="1" MinWidth="150" MaxWidth="300" Style="{StaticResource appTextBoxStyle}">
-            <Binding Path="DateOnlyVal" UpdateSourceTrigger="LostFocus"
+          <TextBox Grid.Row="1" Grid.Column="1" MinWidth="150" MaxWidth="300" Validation.Error="ItemError"
+                   Style="{StaticResource appTextBoxStyle}">
+            <Binding Path="DateOnlyVal" UpdateSourceTrigger="PropertyChanged" NotifyOnValidationError="True"
                      Converter="{StaticResource DateOnlyToString}">
               <Binding.ValidationRules>
-                <cr:DateOnlyRule Property="DateOnlyVal" Rqd="False"
-                                 ValidationStep="RawProposedValue" ValidatesOnTargetUpdated="True"/>
+                <cr:DateOnlyRule Property="DateOnlyVal" Rqd="False"/>
               </Binding.ValidationRules>
             </Binding>
           </TextBox>
@@ -198,12 +199,12 @@
           <!-- IntegerRule -->
           <TextBlock Grid.Row="2" Text="Integer:"
                Style="{StaticResource appTextBlockStyle}"/>
-          <TextBox Grid.Row="2" Grid.Column="1" MinWidth="120" MaxWidth="300" Style="{StaticResource appTextBoxStyle}">
-            <Binding Path="IntegerRule" UpdateSourceTrigger="LostFocus"
+          <TextBox Grid.Row="2" Grid.Column="1" MinWidth="120" MaxWidth="300" Validation.Error="ItemError"
+                   Style="{StaticResource appTextBoxStyle}">
+            <Binding Path="IntegerRule" UpdateSourceTrigger="PropertyChanged" NotifyOnValidationError="True"
                      Converter="{StaticResource IntegerToString}">
               <Binding.ValidationRules>
-                <cr:IntegerRule Property="IntegerRule" Rqd="False"
-                                ValidationStep="RawProposedValue" ValidatesOnTargetUpdated="True"/>
+                <cr:IntegerRule Property="IntegerRule" Rqd="False"/>
               </Binding.ValidationRules>
             </Binding>
           </TextBox>
@@ -211,11 +212,11 @@
           <!-- RequiredRule -->
           <TextBlock Grid.Row="3" Text="Required:"
                      Style="{StaticResource appTextBlockStyle}"/>
-          <TextBox Grid.Row="3" Grid.Column="1" HorizontalAlignment="Stretch"
+          <TextBox Grid.Row="3" Grid.Column="1" HorizontalAlignment="Stretch" Validation.Error="ItemError"
                    Style="{StaticResource appTextBoxStyle}">
-            <Binding Path="StringRule" UpdateSourceTrigger="LostFocus">
+            <Binding Path="StringRule" UpdateSourceTrigger="PropertyChanged" NotifyOnValidationError="True">
               <Binding.ValidationRules>
-                <cr:RequiredRule Property="StringVal" ValidationStep="RawProposedValue" ValidatesOnTargetUpdated="True"/>
+                <cr:RequiredRule Property="StringVal"/>
               </Binding.ValidationRules>
             </Binding>
           </TextBox>

--- a/tests/Integration/Wpf/Views/UnitTestView.xaml.cs
+++ b/tests/Integration/Wpf/Views/UnitTestView.xaml.cs
@@ -30,4 +30,26 @@ public partial class UnitTestView : UserControl
 			}
 		}
 	}
+
+	#region Error handling for Validation Rules Tab
+
+	private UnitTestViewModel? _vm;
+
+	// This event occurs when a ValidationRule in a BindingGroup or a Binding fails.
+	private void ItemError( object sender, ValidationErrorEventArgs e )
+	{
+		if( _vm is null )
+		{
+			if( e.OriginalSource is TextBox tb ) { _vm = tb.DataContext as UnitTestViewModel; }
+			else if( e.OriginalSource is ComboBox cb ) { _vm = cb.DataContext as UnitTestViewModel; }
+		}
+
+		if( _vm is not null )
+		{
+			if( e.Action == ValidationErrorEventAction.Added ) _vm.UIErrors++;
+			else if( e.Action == ValidationErrorEventAction.Removed ) _vm.UIErrors--;
+		}
+	}
+
+	#endregion
 }


### PR DESCRIPTION
## Integration Testing

Closes #51

The Validation Rules do not interact with the view model so the button states cannot be condition correctly.\
The `UnitTestView` code-behind needs to inform the `UnitTestViewModel` whenever an error is raised.

**UnitTestViewModel**:
- Added a `UIErrors` property that can be updated from the View.
- Changed the `CanCommitEdit()` method to also check if `UIErrors = 0` to enable the Save button.
- Changed the `IsDirty()` method to also check if `UIErrors > 0` to enable the Undo button.
- Changed the following properties so they no longer check if the value if different before updating the property\
`ComboEditRule` `DateOnlyVal` `IntegerRule` `StringRule` 

**UnitTestView**:
- Added an `ItemError( object sender, ValidationErrorEventArgs e )` method which updates the `UIErrors` property
on the view model whenever a `ValidationError` is added or removed.
- Invoke the new method using the `Validation.Error="ItemError"` property and binding properties of
`UpdateSourceTrigger="PropertyChanged"` and `NotifyOnValidationError="True"` for the following Rule tab fields:\
`ComboEdit` `DateOnly` `Integer` `Required`
- The validation rule bindings no longer sets the `ValidationStep` and `ValidatesOnTargetUpdated` properties.